### PR TITLE
Adding component for code coverage reporting on jenkins

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -27,6 +27,26 @@ const client = function (mozaik) {
     }
 
     return {
+        coverage(params) {
+            return buildRequest(`/job/${params.job}/lastSuccessfulBuild/${params.reporter}/api/json?depth=2`)
+            .then((res) => {
+                    if(params.reporter === "cobertura") {
+                        return {
+                            function: res.body.results.elements[3].ratio,
+                            line: res.body.results.elements[4].ratio,
+                            branch: res.body.results.elements[5].ratio
+                        }
+                    } else if(params.reporter === "jacoco") {
+                        return {
+                            function: res.body.methodCoverage.percentageFloat,
+                            line: res.body.lineCoverage.percentageFloat,
+                            branch: res.body.branchCoverage.percentageFloat
+                        }
+                    }
+
+                })
+        },
+        
         jobs() {
             return buildRequest('/api/json?tree=jobs[name,lastBuild[number,building,timestamp,result]]&pretty=true')
                 .then(res => res.body.jobs)

--- a/src/components/Coverage.jsx
+++ b/src/components/Coverage.jsx
@@ -1,0 +1,68 @@
+import React, { Component, PropTypes } from 'react';
+import reactMixin                      from 'react-mixin';
+import { ListenerMixin }               from 'reflux';
+import Mozaik                          from 'mozaik/browser'
+
+const informationUnavailableMessage = "Information Unavailable";
+
+class Coverage extends Component {
+
+    constructor() {
+        super();
+        this.state = {
+            coverage:{
+                line: informationUnavailableMessage,
+                function: informationUnavailableMessage,
+                branch: informationUnavailableMessage
+            }
+        };
+    }
+
+    getApiRequest() {
+        return {
+            id: 'jenkins.coverage.' + this.props.job,
+            params: {
+                job: this.props.job,
+                reporter: this.props.reporter
+            }
+        };
+    }
+
+    onApiData(coverage) {
+        this.setState({
+            coverage: {
+                function: coverage.function,
+                line:  coverage.line,
+                branch: coverage.branch
+            }
+        });
+    }
+
+    render() {
+        let classes = `list__item`;
+
+        return (
+            <div>
+                <div className="widget__header">
+                    {this.props.title || "Code Coverage"}
+                </div>
+                <div className={classes}>
+                    Line Coverage: {this.state.coverage.line}
+                </div>
+                <div className={classes}>
+                    Function Coverage: {this.state.coverage.function}
+                </div>
+                <div className={classes}>
+                    Branch Coverage: {this.state.coverage.branch}
+                </div>
+
+
+            </div>
+        );
+    }
+}
+
+reactMixin(Coverage.prototype, ListenerMixin);
+reactMixin(Coverage.prototype, Mozaik.Mixin.ApiConsumer);
+
+export { Coverage as default };

--- a/src/components/JobStatus.jsx
+++ b/src/components/JobStatus.jsx
@@ -41,6 +41,12 @@ var JobStatus = React.createClass({
 
         if (this.state.builds.length > 0) {
             var currentBuild = this.state.builds[0];
+
+            //Show pass/fail status only.
+            if (currentBuild.building === true && this.state.builds.length > 1) {
+                currentBuild = this.state.builds[1];
+            }
+
             if (currentBuild.result === 'SUCCESS') {
                 iconClasses = 'fa fa-check';
             }

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -3,5 +3,6 @@ module.exports = {
     JobStatus:          require('./JobStatus.jsx'),
     JobBuilds:          require('./JobBuilds.jsx'),
     JobBuildsHistogram: require('./JobBuildsHistogram.jsx'),
-    View:               require('./View.jsx')
+    View:               require('./View.jsx'),
+    Coverage:           require('./Coverage.jsx')
 };


### PR DESCRIPTION
This PR adds a basic widget for reporting code coverage stats provided by Cobertura and Jacoco on Jenkins. 

This is pretty basic right now. Potential enhancements include allowing users to set "thesholds", which would style coverage info as green/yellow/red depending on how high/low it was. 
