### PR TITLE
Allow buildRequest to log error

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -33,6 +33,10 @@ const client = mozaik => {
                 config.get('jenkins.basicAuthPassword')
             )
             .promise()
+            .catch(error => {
+                mozaik.logger.error(chalk.red(`[jenkins] ${ error.error }`));
+                throw error;
+            })
         ;
     }
 


### PR DESCRIPTION
I was fiddling around and couldn't get jenkins working, so I added logging of an extra line to output in order to make it clear why jenkins is not working. Example:

before

```
error: [jenkins] jenkins.job.klear-dev-test  - status code: undefined
```

after

```
error: [jenkins] Error: unable to verify the first certificate
error: [jenkins] jenkins.job.klear-dev-test  - status code: undefined
```
