### PR TITLE
Add building status to JobBuild

### DIFF
--- a/src/components/JobBuild.jsx
+++ b/src/components/JobBuild.jsx
@@ -6,11 +6,11 @@ class JobBuild extends Component {
     render() {
         const { build } = this.props;
 
-        const classes = `list__item list__item--with-status list__item--with-status--${ build.result.toLowerCase() }`;
+        const classes = `list__item list__item--with-status list__item--with-status--${ this.buildResult().toLowerCase() }`;
 
         return (
             <div className={classes}>
-                #{build.number} {build.result}&nbsp;
+                #{build.number} {this.buildResult()}&nbsp;
                 <time className="list__item__time">
                     <i className="fa fa-clock-o" />&nbsp;
                     {moment(build.timestamp, 'x').fromNow()}
@@ -18,12 +18,27 @@ class JobBuild extends Component {
             </div>
         );
     }
+
+    buildResult() {
+        const { build } = this.props;
+
+        if (build.result) {
+            return build.result;
+        }
+
+        if (build.building) {
+            return 'BUILDING';
+        }
+
+        return 'UNKNOWN';
+    }
 }
 
 JobBuild.displayName = 'JobBuild';
 
 JobBuild.propTypes = {
     build: PropTypes.shape({
+        building:  PropTypes.bool.isRequired,
         number:    PropTypes.number.isRequired,
         result:    PropTypes.string.isRequired,
         timestamp: PropTypes.number.isRequired

--- a/src/components/JobBuild.jsx
+++ b/src/components/JobBuild.jsx
@@ -1,36 +1,23 @@
 import React, { Component, PropTypes } from 'react'; // eslint-disable-line no-unused-vars
 import moment                          from 'moment';
+import { getBuildStatus }              from './util';
 
 
 class JobBuild extends Component {
     render() {
         const { build } = this.props;
 
-        const classes = `list__item list__item--with-status list__item--with-status--${ this.buildResult().toLowerCase() }`;
+        const classes = `list__item list__item--with-status list__item--with-status--${ getBuildStatus(build).toLowerCase() }`;
 
         return (
             <div className={classes}>
-                #{build.number} {this.buildResult()}&nbsp;
+                #{build.number} {getBuildStatus(build)}&nbsp;
                 <time className="list__item__time">
                     <i className="fa fa-clock-o" />&nbsp;
                     {moment(build.timestamp, 'x').fromNow()}
                 </time>
             </div>
         );
-    }
-
-    buildResult() {
-        const { build } = this.props;
-
-        if (build.result) {
-            return build.result;
-        }
-
-        if (build.building) {
-            return 'BUILDING';
-        }
-
-        return 'UNKNOWN';
     }
 }
 

--- a/src/components/util.js
+++ b/src/components/util.js
@@ -1,0 +1,16 @@
+const JENKINS_BUILD_STATUS_BUILDING = 'BUILDING';
+const JENKINS_BUILD_STATUS_UNKNOWN  = 'UNKNOWN';
+
+/**
+ * Returns a build status from given build info.
+ *
+ * @param {object} build - the Jenkins build object
+ * @returns {string}
+ */
+export const getBuildStatus = (build) => {
+    if (build.result) {
+        return build.result;
+    }
+
+    return build.building ? JENKINS_BUILD_STATUS_BUILDING : JENKINS_BUILD_STATUS_UNKNOWN;
+};

--- a/styl/components/_list.styl
+++ b/styl/components/_list.styl
@@ -1,0 +1,5 @@
+.list
+  &__item
+    &--with-status
+      &--building:before
+        background-color $unknown-color

--- a/styl/components/_list.styl
+++ b/styl/components/_list.styl
@@ -1,5 +1,0 @@
-.list
-  &__item
-    &--with-status
-      &--building:before
-        background-color $unknown-color

--- a/styl/index.styl
+++ b/styl/index.styl
@@ -1,5 +1,4 @@
 @require "_view.styl"
-@require "components/_list"
 
 .jenkins
   &__job-builds_histogram

--- a/styl/index.styl
+++ b/styl/index.styl
@@ -1,4 +1,5 @@
 @require "_view.styl"
+@require "components/_list"
 
 .jenkins
   &__job-builds_histogram
@@ -82,7 +83,7 @@
       display flex
       width 100%
       height 100%
-      text-align center  
+      text-align center
       & .jenkins
         &__job-status
           &__current

--- a/test/components/JobBuild.test.js
+++ b/test/components/JobBuild.test.js
@@ -4,10 +4,11 @@ import { shallow } from 'enzyme';
 import JobBuild    from '../../src/components/JobBuild.jsx';
 
 
-test('should display job build number and status', t => {
+test('should display successful job build number and status', t => {
     const build = {
         number:    13,
         result:    'SUCCESS',
+        building:  false,
         timestamp: 1457624704782
     };
 
@@ -15,4 +16,17 @@ test('should display job build number and status', t => {
 
     t.regex(wrapper.find('.list__item--with-status').prop('className'), /list__item--with-status--success/);
     t.regex(wrapper.text(), new RegExp(`#${build.number} ${build.result}`));
+});
+
+test('should display building job build number and status', t => {
+    const build   = {
+        number:    13,
+        result:    null,
+        building:  true,
+        timestamp: 1457624704782
+    };
+    const wrapper = shallow(<JobBuild build={build} />);
+
+    t.regex(wrapper.find('.list__item--with-status').prop('className'), /list__item--with-status--building/);
+    t.regex(wrapper.text(), new RegExp(`#${build.number} BUILDING`));
 });


### PR DESCRIPTION
This commit adds support for a currently building Jenkins job
for the JobBuild widget.

Resolves #14

I figured making the change and getting a couple screenshots in front of you would help me show what I was thinking for this feature.
### Building

<img width="424" alt="2016-03-29 at 5 09 pm building" src="https://cloud.githubusercontent.com/assets/2344137/14124080/bc3b523e-f5d1-11e5-93ef-e04de8eaf991.png">
### Success

<img width="421" alt="2016-03-29 at 5 10 pm success" src="https://cloud.githubusercontent.com/assets/2344137/14124079/bc3b4cf8-f5d1-11e5-94db-08574386a75e.png">
