### PR TITLE
Remove trailing whitespace from JobBuilds.id

### DIFF
--- a/src/components/JobBuilds.jsx
+++ b/src/components/JobBuilds.jsx
@@ -16,7 +16,7 @@ class JobBuilds extends Component {
         const { job } = this.props;
 
         return {
-            id:     `jenkins.job.${job} `,
+            id:     `jenkins.job.${job}`,
             params: { job }
         };
     }


### PR DESCRIPTION
This commit removes an extra space that gets logged from a JobBuilds
widget.

Previously, the following was logged:

`info: Calling 'jenkins.job.my-repo '`

This commit fixes it to read:

`info: Calling 'jenkins.job.my-repo'`
